### PR TITLE
feat: add support for extra tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ No resources.
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name | `string` | n/a | yes |
 | <a name="input_owner"></a> [owner](#input\_owner) | The name of the component owner | `string` | n/a | yes |
 | <a name="input_service"></a> [service](#input\_service) | The name of the service related to the component | `string` | n/a | yes |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | A map of optional extra tags to be validated and included in the output | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/examples/invalid-tags/main.tf
+++ b/examples/invalid-tags/main.tf
@@ -4,4 +4,11 @@ module "tags" {
   environment = "sandbox"
   service     = "serviceWithUppercaseLetters"
   owner       = "2023invalid"
+
+  extra_tags = {
+    keyWithUppercase            = 1
+    key_with_underscore         = 1
+    "1-key-with-leading-number" = 1
+    key-with-trailing-dash-     = 1
+  }
 }

--- a/examples/valid-tags/main.tf
+++ b/examples/valid-tags/main.tf
@@ -4,4 +4,10 @@ module "tags" {
   environment = "development"
   service     = "tf-examples"
   owner       = "infra"
+
+  extra_tags = {
+    extra             = 1
+    key-with-dash     = "true"
+    key-with-1-number = "example"
+  }
 }

--- a/examples/valid-tags/main.tf
+++ b/examples/valid-tags/main.tf
@@ -6,8 +6,9 @@ module "tags" {
   owner       = "infra"
 
   extra_tags = {
-    extra             = 1
-    key-with-dash     = "true"
-    key-with-1-number = "example"
+    extra                     = 1
+    key-with-dash             = true
+    key-with-1-number         = "example"
+    key-with-trailing-number1 = "another"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -3,12 +3,15 @@
 # ------------------------------------------------------------------------------
 
 locals {
-  tags = {
-    created-by  = "terraform"
-    environment = var.environment
-    owner       = var.owner
-    service     = var.service
-  }
+  tags = merge(
+    {
+      created-by  = "terraform"
+      environment = var.environment
+      owner       = var.owner
+      service     = var.service
+    },
+    var.extra_tags
+  )
 
   tags_for_asg = [
     for k, v in local.tags :

--- a/test/valid_tags_test.go
+++ b/test/valid_tags_test.go
@@ -50,5 +50,6 @@ func TestValidTags(t *testing.T) {
 		assert.Contains(t, tags, "extra", "The 'tags' output should contain the 'extra' key.")
 		assert.Contains(t, tags, "key-with-dash", "The 'tags' output should contain the 'key-with-dash' key.")
 		assert.Contains(t, tags, "key-with-1-number", "The 'tags' output should contain the 'key-with-1-number' key.")
+		assert.Contains(t, tags, "key-with-trailing-number1", "The 'tags' output should contain the 'key-with-trailing-number1' key.")
 	})
 }

--- a/test/valid_tags_test.go
+++ b/test/valid_tags_test.go
@@ -43,9 +43,12 @@ func TestValidTags(t *testing.T) {
 
 		tags := terraform.OutputMap(t, terraformOptions, "tags")
 
-		assert.Contains(t, tags, "created-by", "The 'tags' output does not contain the 'created-by' tag.")
-		assert.Contains(t, tags, "environment", "The 'tags' output does not contain the 'environment' tag.")
-		assert.Contains(t, tags, "owner", "The 'tags' output does not contain the 'owner' tag.")
-		assert.Contains(t, tags, "service", "The 'tags' output does not contain the 'service' tag.")
+		assert.Contains(t, tags, "created-by", "The 'tags' output should contain the 'created-by' key.")
+		assert.Contains(t, tags, "environment", "The 'tags' output should contain the 'environment' key.")
+		assert.Contains(t, tags, "owner", "The 'tags' output should contain the 'owner' key.")
+		assert.Contains(t, tags, "service", "The 'tags' output should contain the 'service' key.")
+		assert.Contains(t, tags, "extra", "The 'tags' output should contain the 'extra' key.")
+		assert.Contains(t, tags, "key-with-dash", "The 'tags' output should contain the 'key-with-dash' key.")
+		assert.Contains(t, tags, "key-with-1-number", "The 'tags' output should contain the 'key-with-1-number' key.")
 	})
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,17 @@ variable "owner" {
     error_message = "The owner name must start with a lower case letter and can only contain lower case letters, numbers and dashes (-)."
   }
 }
+
+variable "extra_tags" {
+  description = "A map of optional extra tags to be validated and included in the output"
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = can([
+      for key in keys(var.extra_tags) :
+      regex("^[a-z][a-z0-9-]*[a-z0-9]$", key)
+    ])
+    error_message = "All extra tag keys name must start with a lower case letter and can only contain lower case letters, numbers and dashes (-)."
+  }
+}


### PR DESCRIPTION
Add the optional `extra_tags` input for additional validated tags.